### PR TITLE
Regeression: fix unit tests target framework detection: 

### DIFF
--- a/src/ObjectDumper/DebuggeeInteraction/ExpressionProviders/CSharpFSharpExpressionProvider.cs
+++ b/src/ObjectDumper/DebuggeeInteraction/ExpressionProviders/CSharpFSharpExpressionProvider.cs
@@ -4,7 +4,7 @@
     {
         public string GetTargetFrameworkExpressionText()
         {
-            return "System.AppContext.TargetFrameworkName";
+            return "System.AppContext.TargetFrameworkName?.StartsWith(\".NETFra\") != false ? System.AppContext.TargetFrameworkName : System.AppContext.TargetFrameworkName?.Split(\",\")[0] + \",Version=v\" + System.Environment.Version";
         }
 
         public string GetIsSerializerInjectedExpressionText()

--- a/src/ObjectDumper/DebuggeeInteraction/ExpressionProviders/VisualBasicExpressionProvider.cs
+++ b/src/ObjectDumper/DebuggeeInteraction/ExpressionProviders/VisualBasicExpressionProvider.cs
@@ -4,7 +4,7 @@
     {
         public string GetTargetFrameworkExpressionText()
         {
-            return "System.AppContext.TargetFrameworkName";
+            return "If(System.AppContext.TargetFrameworkName?.StartsWith(\".NETFra\") <> False, System.AppContext.TargetFrameworkName, System.AppContext.TargetFrameworkName?.Split(\",\")(0) & \",Version=v\" & System.Environment.Version.ToString)";
         }
 
         public string GetIsSerializerInjectedExpressionText()

--- a/src/ObjectDumper/DebuggeeInteraction/InteractionService.cs
+++ b/src/ObjectDumper/DebuggeeInteraction/InteractionService.cs
@@ -98,10 +98,16 @@ namespace ObjectDumper.DebuggeeInteraction
                         : (true, "net45");
 
                 case ".netcoreapp":
+                    if (version < new Version(2, 0))
+                    {
+                        return (false, "The .NET Core with a version lower than 2.0 is not supported.");
+                    }
+
                     if (version < new Version(3, 1))
                     {
-                        return (false, "The .NET Core with a version lower than 3.1 is not supported.");
+                        return (true, "netstandard2.0");
                     }
+
                     return version >= new Version(6, 0)
                         ? (true, "net6.0")
                         : (true, "netcoreapp3.1");


### PR DESCRIPTION
MS Test runner always returns .netcore 2.0, Resharper test runner always returns .netcore 3.0 regardless of test project targetframework settings (.NET6.0)