### PR TITLE
fix: Error shown for anything I try and use #49

### DIFF
--- a/src/ObjectDumper/DebuggeeInteraction/ExpressionProviders/CSharpFSharpExpressionProvider.cs
+++ b/src/ObjectDumper/DebuggeeInteraction/ExpressionProviders/CSharpFSharpExpressionProvider.cs
@@ -4,7 +4,7 @@
     {
         public string GetTargetFrameworkExpressionText()
         {
-            return "System.AppContext.TargetFrameworkName?.StartsWith(\".NETFra\") != false ? System.AppContext.TargetFrameworkName : System.AppContext.TargetFrameworkName?.Split(\",\")[0] + \",Version=v\" + System.Environment.Version";
+            return "System.AppContext.TargetFrameworkName?.StartsWith(\".NETFra\") != false ? System.AppContext.TargetFrameworkName : System.AppContext.TargetFrameworkName?.Split(',')[0] + \",Version=v\" + System.Environment.Version";
         }
 
         public string GetIsSerializerInjectedExpressionText()

--- a/src/ObjectDumper/Properties/AssemblyInfo.cs
+++ b/src/ObjectDumper/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.0.75")]
-[assembly: AssemblyFileVersion("0.0.0.75")]
+[assembly: AssemblyVersion("0.0.0.76")]
+[assembly: AssemblyFileVersion("0.0.0.76")]

--- a/src/ObjectDumper/source.extension.vsixmanifest
+++ b/src/ObjectDumper/source.extension.vsixmanifest
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ObjectDumper.7c57976c-bdc9-4edc-a4fd-48c114054ad5" Version="0.0.0.75" Language="en-US" Publisher="Yevhen Cherkes" />
+        <Identity Id="ObjectDumper.7c57976c-bdc9-4edc-a4fd-48c114054ad5" Version="0.0.0.76" Language="en-US" Publisher="Yevhen Cherkes" />
         <DisplayName>Object Dumper</DisplayName>
-        <Description xml:space="preserve">Object Dumper is an open source Visual Studio and Visual Studio Code extension for exporting in-memory objects during debugging to C#, JSON, VB, XML, and YAML.</Description>
+        <Description xml:space="preserve">Object Dumper is an open source Visual Studio and Visual Studio Code extension for exporting in-memory objects during debugging to C#, JSON, VB, XML, and YAML string.</Description>
         <License>LICENSE.txt</License>
         <Icon>Resources\PackageIcon.png</Icon>
         <Tags>Debugging Exporting C# JSON VisualBasic XML YAML</Tags>


### PR DESCRIPTION
error CS1503: Argument 1: cannot convert from 'string' to 'char'

.NetFramework doesn't have a string.Split(",") method, replaced with string.Split(',').