### PR TITLE
Fix target framework detection when debugging the vs extension.  (Unexpected spaces)

### DIFF
--- a/src/ObjectDumper/DebuggeeInteraction/InteractionService.cs
+++ b/src/ObjectDumper/DebuggeeInteraction/InteractionService.cs
@@ -78,7 +78,7 @@ namespace ObjectDumper.DebuggeeInteraction
                 return (false, $"Wrong TargetFramework: {targetFrameworkName}");
             }
 
-            var match = Regex.Match(targetFrameworkName, "(?<frameworkName>.+?),Version=v(?<frameworkVersion>\\d+(\\.\\d+)+?)", RegexOptions.Compiled);
+            var match = Regex.Match(targetFrameworkName, "(?<frameworkName>.+?),\\s*Version\\s*=\\s*v(?<frameworkVersion>\\d+(\\.\\d+)+?)", RegexOptions.Compiled);
 
             if (!match.Success ||
                 !match.Groups["frameworkVersion"].Success ||

--- a/src/ObjectDumper/PackageConstants.cs
+++ b/src/ObjectDumper/PackageConstants.cs
@@ -3,6 +3,6 @@
     internal static class PackageConstants
     {
         public const string Id = "75562b3a-ff38-4ad7-94f8-dc7f08140914";
-        public const string Version = "0.0.0.81";
+        public const string Version = "0.0.0.82";
     }
 }

--- a/src/ObjectDumper/source.extension.vsixmanifest
+++ b/src/ObjectDumper/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
 	<Metadata>
-		<Identity Id="ObjectDumper.7c57976c-bdc9-4edc-a4fd-48c114054ad5" Version="0.0.0.81" Language="en-US" Publisher="Yevhen Cherkes" />
+		<Identity Id="ObjectDumper.7c57976c-bdc9-4edc-a4fd-48c114054ad5" Version="0.0.0.82" Language="en-US" Publisher="Yevhen Cherkes" />
 		<DisplayName>Object Dumper</DisplayName>
 		<Description xml:space="preserve">Extension for exporting in-memory objects during debugging to C#, JSON, VB, XML, and YAML string.</Description>
 		<License>LICENSE.txt</License>


### PR DESCRIPTION
The System.AppContext.TargetFrameworkName returns ".NETFramework, Version = v4.7.2" in opposite to ".NETFramework,Version=v4.7.2" when debugging the Visual Studio extension.